### PR TITLE
style(change): order time formatted to hh:mm:ss

### DIFF
--- a/application/src/App.js
+++ b/application/src/App.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
-import { Provider } from 'react-redux';
-import AppRouter from './router/appRouter';
-import store from './redux/store';
-import './App.css';
+import React, { Component } from "react";
+import { Provider } from "react-redux";
+import AppRouter from "./router/appRouter";
+import store from "./redux/store";
+import "./App.css";
 
 class App extends Component {
   render() {
@@ -10,7 +10,7 @@ class App extends Component {
       <Provider store={store}>
         <AppRouter />
       </Provider>
-    )
+    );
   }
 }
 

--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -1,66 +1,73 @@
-import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { Template } from '../../components';
-import { SERVER_IP } from '../../private';
-import './orderForm.css';
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { Template } from "../../components";
+import { SERVER_IP } from "../../private";
+import "./orderForm.css";
 
 const ADD_ORDER_URL = `${SERVER_IP}/api/add-order`;
 
 export default function OrderForm(props) {
-    const [orderItem, setOrderItem] = useState("");
-    const [quantity, setQuantity] = useState("1");
+  const [orderItem, setOrderItem] = useState("");
+  const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+  const menuItemChosen = (event) => setOrderItem(event.target.value);
+  const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
-    const auth = useSelector((state) => state.auth);
+  const auth = useSelector((state) => state.auth);
 
-    const submitOrder = () => {
-        if (orderItem === "") return;
-        fetch(ADD_ORDER_URL, {
-            method: 'POST',
-            body: JSON.stringify({
-                order_item: orderItem,
-                quantity,
-                ordered_by: auth.email || 'Unknown!',
-            }),
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        })
-        .then(res => res.json())
-        .then(response => console.log("Success", JSON.stringify(response)))
-        .catch(error => console.error(error));
-    }
+  const submitOrder = (event) => {
+    event.preventDefault();
+    if (orderItem === "") return;
+    fetch(ADD_ORDER_URL, {
+      method: "POST",
+      body: JSON.stringify({
+        order_item: orderItem,
+        quantity,
+        ordered_by: auth.email || "Unknown!",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((res) => res.json())
+      .then((response) => console.log("Success", JSON.stringify(response)))
+      .catch((error) => console.error(error));
+  };
 
-    return (
-        <Template>
-            <div className="form-wrapper">
-                <form>
-                    <label className="form-label">I'd like to order...</label><br />
-                    <select 
-                        value={orderItem} 
-                        onChange={(event) => menuItemChosen(event)}
-                        className="menu-select"
-                    >
-                        <option value="" defaultValue disabled hidden>Lunch menu</option>
-                        <option value="Soup of the Day">Soup of the Day</option>
-                        <option value="Linguini With White Wine Sauce">Linguini With White Wine Sauce</option>
-                        <option value="Eggplant and Mushroom Panini">Eggplant and Mushroom Panini</option>
-                        <option value="Chili Con Carne">Chili Con Carne</option>
-                    </select><br />
-                    <label className="qty-label">Qty:</label>
-                    <select value={quantity} onChange={(event) => menuQuantityChosen(event)}>
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
-                        <option value="4">4</option>
-                        <option value="5">5</option>
-                        <option value="6">6</option>
-                    </select>
-                    <button type="button" className="order-btn" onClick={() => submitOrder()}>Order It!</button>
-                </form>
-            </div>
-        </Template>
-    )
+  return (
+    <Template>
+      <div className="form-wrapper">
+        <form>
+          <label className="form-label">I'd like to order...</label>
+          <br />
+          <select
+            value={orderItem}
+            onChange={(event) => menuItemChosen(event)}
+            className="menu-select"
+          >
+            <option value="" defaultValue disabled hidden>
+              Lunch menu
+            </option>
+            <option value="Soup of the Day">Soup of the Day</option>
+            <option value="Linguini With White Wine Sauce">Linguini With White Wine Sauce</option>
+            <option value="Eggplant and Mushroom Panini">Eggplant and Mushroom Panini</option>
+            <option value="Chili Con Carne">Chili Con Carne</option>
+          </select>
+          <br />
+          <label className="qty-label">Qty:</label>
+          <select value={quantity} onChange={(event) => menuQuantityChosen(event)}>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+          </select>
+          <button type="submit" className="order-btn" onClick={(event) => submitOrder(event)}>
+            Order It!
+          </button>
+        </form>
+      </div>
+    </Template>
+  );
 }

--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,32 +1,38 @@
-import React from 'react';
+import React from "react";
 
 const OrdersList = (props) => {
-    const { orders } = props;
-    if (!props || !props.orders || !props.orders.length) return (
-        <div className="empty-orders">
-            <h2>There are no orders to display</h2>
-        </div>
+  const { orders } = props;
+  if (!props || !props.orders || !props.orders.length)
+    return (
+      <div className="empty-orders">
+        <h2>There are no orders to display</h2>
+      </div>
     );
 
-    return orders.map(order => {
-        const createdDate = new Date(order.createdAt);
-        return (
-            <div className="row view-order-container" key={order._id}>
-                <div className="col-md-4 view-order-left-col p-3">
-                    <h2>{order.order_item}</h2>
-                    <p>Ordered by: {order.ordered_by || ''}</p>
-                </div>
-                <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
-                    <p>Quantity: {order.quantity}</p>
-                </div>
-                <div className="col-md-4 view-order-right-col">
-                    <button className="btn btn-success">Edit</button>
-                    <button className="btn btn-danger">Delete</button>
-                </div>
-            </div>
-        );
-    });
-}
+  return orders.map((order) => {
+    const createdDate = new Date(order.createdAt);
+    return (
+      <div className="row view-order-container" key={order._id}>
+        <div className="col-md-4 view-order-left-col p-3">
+          <h2>{order.order_item}</h2>
+          <p>Ordered by: {order.ordered_by || ""}</p>
+        </div>
+        <div className="col-md-4 d-flex view-order-middle-col">
+          <p>
+            Order placed at{" "}
+            {`${createdDate.getHours()}:${
+              (createdDate.getMinutes() < 10 ? "0" : "") + createdDate.getMinutes()
+            }:${(createdDate.getSeconds() < 10 ? "0" : "") + createdDate.getSeconds()}`}
+          </p>
+          <p>Quantity: {order.quantity}</p>
+        </div>
+        <div className="col-md-4 view-order-right-col">
+          <button className="btn btn-success">Edit</button>
+          <button className="btn btn-danger">Delete</button>
+        </div>
+      </div>
+    );
+  });
+};
 
 export default OrdersList;


### PR DESCRIPTION
## Changes
1. Added ternary to the minutes and seconds of createdAt. 

## Purpose
The issue was that when minutes and/or secons was less than 10 it would display as a singular number without a 0.

## Approach
This change adds a padding 0 when minutes and/or seconds are less than 10.

## Pre-Testing TODOs
NA

## Testing Steps
Make an order when its > 10 seconds to view the padding 0 in its full glory in the /view-orders page.

## Learning
I researched different methods to add a padding zero, this seemed to the be most simple way. I didnt want to complicate myself nor add any dependencies for time. 

Bug: order time does not format time correctly
Closes #002